### PR TITLE
Expose router stats port when prometheus is installed

### DIFF
--- a/roles/openshift_hosted/defaults/main.yml
+++ b/roles/openshift_hosted/defaults/main.yml
@@ -66,7 +66,10 @@ openshift_hosted_router_certificate: {}
 openshift_hosted_router_create_certificate: True
 
 r_openshift_hosted_router_os_firewall_deny: []
-r_openshift_hosted_router_os_firewall_allow: []
+r_openshift_hosted_router_os_firewall_allow:
+- service: Router Statistics Port
+  port: "{{ stats_port }}/tcp"
+  cond: "{{ openshift_prometheus_state == 'present' }}"
 
 ############
 # Registry #

--- a/roles/openshift_hosted/defaults/main.yml
+++ b/roles/openshift_hosted/defaults/main.yml
@@ -30,6 +30,7 @@ openshift_hosted_images_dict:
 ##########
 r_openshift_hosted_router_firewall_enabled: "{{ os_firewall_enabled | default(True) }}"
 r_openshift_hosted_router_use_firewalld: "{{ os_firewall_use_firewalld | default(False) }}"
+r_openshift_hosted_router_prometheus_enabled: "{{ openshift_prometheus_state == 'present' | default(True) }}"
 
 openshift_hosted_router_selector: "{{ openshift_router_selector | default(openshift_hosted_infra_selector) }}"
 openshift_hosted_router_namespace: 'default'
@@ -69,7 +70,7 @@ r_openshift_hosted_router_os_firewall_deny: []
 r_openshift_hosted_router_os_firewall_allow:
 - service: Router Statistics Port
   port: "{{ stats_port }}/tcp"
-  cond: "{{ openshift_prometheus_state == 'present' }}"
+  cond: "{{ r_openshift_hosted_router_prometheus_enabled }}"
 
 ############
 # Registry #

--- a/roles/openshift_hosted/defaults/main.yml
+++ b/roles/openshift_hosted/defaults/main.yml
@@ -30,7 +30,7 @@ openshift_hosted_images_dict:
 ##########
 r_openshift_hosted_router_firewall_enabled: "{{ os_firewall_enabled | default(True) }}"
 r_openshift_hosted_router_use_firewalld: "{{ os_firewall_use_firewalld | default(False) }}"
-r_openshift_hosted_router_prometheus_enabled: "{{ openshift_prometheus_state == 'present' | default(True) }}"
+r_openshift_hosted_router_prometheus_enabled: "{{ openshift_prometheus_state is defined and openshift_prometheus_state == 'present' | default(True) }}"
 
 openshift_hosted_router_selector: "{{ openshift_router_selector | default(openshift_hosted_infra_selector) }}"
 openshift_hosted_router_namespace: 'default'


### PR DESCRIPTION
The PR 6636 has been closed on the officially repository, but the port
issue is not resolved.