### PR TITLE
Allow dict and pairs for Kibana and Curator node selector

### DIFF
--- a/roles/lib_utils/filter_plugins/oo_filters.py
+++ b/roles/lib_utils/filter_plugins/oo_filters.py
@@ -679,6 +679,10 @@ def map_to_pairs(source, delim="="):
     if source == {} or source == '':
         return str()
 
+    # Return early if if input already is a pairs string.
+    if isinstance(source, basestring):
+        return source
+
     return ','.join(["{}{}{}".format(key, delim, value) for key, value in iteritems(source)])
 
 

--- a/roles/openshift_logging_curator/tasks/main.yaml
+++ b/roles/openshift_logging_curator/tasks/main.yaml
@@ -82,7 +82,7 @@
         curator_cpu_request: "{{ openshift_logging_curator_cpu_request | min_cpu(openshift_logging_curator_cpu_limit | default(none)) }}"
         curator_memory_limit: "{{ openshift_logging_curator_memory_limit }}"
         curator_replicas: "{{ openshift_logging_curator_replicas | default (1) }}"
-        curator_node_selector: "{{openshift_logging_curator_nodeselector | default({})}}"
+        curator_node_selector: "{{openshift_logging_curator_nodeselector | default({}) | map_from_pairs }}"
       check_mode: no
       changed_when: no
 
@@ -144,7 +144,7 @@
         curator_cpu_limit: "{{ openshift_logging_curator_cpu_limit }}"
         curator_cpu_request: "{{ openshift_logging_curator_cpu_request | min_cpu(openshift_logging_curator_cpu_limit | default(none)) }}"
         curator_memory_limit: "{{ openshift_logging_curator_memory_limit }}"
-        curator_node_selector: "{{openshift_logging_curator_nodeselector | default({})}}"
+        curator_node_selector: "{{openshift_logging_curator_nodeselector | default({}) | map_from_pairs }}"
         cron_job_schedule: "{{ openshift_logging_curator_run_minute | default(0) }} {{ openshift_logging_curator_run_hour | default(0) }} * * *"
       check_mode: no
       changed_when: no

--- a/roles/openshift_logging_kibana/tasks/main.yaml
+++ b/roles/openshift_logging_kibana/tasks/main.yaml
@@ -248,7 +248,7 @@
     kibana_proxy_cpu_request: "{{ openshift_logging_kibana_proxy_cpu_request | min_cpu(openshift_logging_kibana_proxy_cpu_limit | default(none)) }}"
     kibana_proxy_memory_limit: "{{ openshift_logging_kibana_proxy_memory_limit }}"
     kibana_replicas: "{{ openshift_logging_kibana_replicas | default (1) }}"
-    kibana_node_selector: "{{ openshift_logging_kibana_nodeselector | default({}) }}"
+    kibana_node_selector: "{{ openshift_logging_kibana_nodeselector | default({}) | map_from_pairs }}"
     kibana_env_vars: "{{ openshift_logging_kibana_env_vars | default({}) }}"
 
 - name: Set Kibana DC


### PR DESCRIPTION
This PR changes the behaviour of the `map_to_pairs` filter so that it will not fail if the input is already a string. This matches the behaviour of its counter part `map_from_pairs` where the input can be both a dictionary or a string.

This changed filter then gets applied to the node selectors of Kibana and the curator for logging.

With this change, we can set the variables `openshift_logging_kibana_nodeselector` and `openshift_logging_curator_nodeselector` equal to `openshift_hosted_infra_selector` without having to think about if it is a dictionary or a key value pairs string.