### PR TITLE
Create KUBELET_HOSTNAME_OVERRIDE on every node config change

### DIFF
--- a/roles/openshift_node/tasks/config.yml
+++ b/roles/openshift_node/tasks/config.yml
@@ -25,6 +25,12 @@
     create: true
   with_dict: "{{ openshift_node_env_vars }}"
 
+- name: Place openshift_kubelet_name_override file
+  template:
+    src: KUBELET_HOSTNAME_OVERRIDE.j2
+    dest: "/etc/sysconfig/KUBELET_HOSTNAME_OVERRIDE"
+  when: openshift_kubelet_name_override is defined
+
 - name: Ensure the node static pod directory exists
   file:
     path: "{{ openshift.common.config_base }}/node/pods"


### PR DESCRIPTION
The default behavior of openshift-ansible is to create the
kubelet name override file KUBELET_HOSTNAME_OVERRIDE just
in a case of an upgrade. We do need to have this also for
new node installations.