### PR TITLE
Ensure that metrics node selectors are dicts

### DIFF
--- a/roles/openshift_metrics/tasks/install_cassandra.yaml
+++ b/roles/openshift_metrics/tasks/install_cassandra.yaml
@@ -26,7 +26,7 @@
     node: "{{ item }}"
     master: "{{ (item == '1')|string|lower }}"
     replica_count: "{{cassandra_replica_count.results[item|int - 1].stdout}}"
-    node_selector: "{{openshift_metrics_cassandra_nodeselector | default('') }}"
+    node_selector: "{{openshift_metrics_cassandra_nodeselector | default('') | map_from_pairs }}"
     fsgroup: "{{ openshift_metrics_namespace_fsgroup }}"
     run_as_uid: "{{ openshift_metrics_namespace_uid }}"
     selinux_level: "{{ openshift_metrics_namespace_selinux }}"

--- a/roles/openshift_metrics/tasks/install_hawkular.yaml
+++ b/roles/openshift_metrics/tasks/install_hawkular.yaml
@@ -21,7 +21,7 @@
     dest: "{{ mktemp.stdout }}/templates/hawkular_metrics_rc.yaml"
   vars:
     replica_count: "{{hawkular_metrics_replica_count.stdout | default(0)}}"
-    node_selector: "{{openshift_metrics_hawkular_nodeselector | default('') }}"
+    node_selector: "{{openshift_metrics_hawkular_nodeselector | default('') | map_from_pairs }}"
   changed_when: false
 
 - name: read hawkular-metrics route destination ca certificate

--- a/roles/openshift_metrics/tasks/install_heapster.yaml
+++ b/roles/openshift_metrics/tasks/install_heapster.yaml
@@ -19,7 +19,7 @@
   template: src=heapster.j2 dest={{mktemp.stdout}}/templates/metrics-heapster-rc.yaml
   vars:
     replica_count: "{{heapster_replica_count.stdout | default(0)}}"
-    node_selector: "{{openshift_metrics_heapster_nodeselector | default('') }}"
+    node_selector: "{{openshift_metrics_heapster_nodeselector | default('') | map_from_pairs }}"
   changed_when: no
 
 - set_fact:


### PR DESCRIPTION
The replication controllers for cassandra, hawkular and heapster expect
a python dict containing the node selectors, but the respective tasks
provide a string. This is unfortunate because the check in the template
which decides if there are any selectors to apply returns true both in
the presence of a non-empty string and a non-empty dict.

This commit applies `map_from_pairs` to the configured node selector
variables to ensure that the templates are provided with the node
selectors in a dict.