### PR TITLE
Workaround buggy 'oc replace --force'

### DIFF
--- a/roles/lib_openshift/src/lib/base.py
+++ b/roles/lib_openshift/src/lib/base.py
@@ -97,6 +97,7 @@ class OpenShiftCLI(object):
         cmd = ['replace', '-f', fname]
         if force:
             cmd.append('--force')
+            cmd.append('--cascade=true')
         return self.openshift_cmd(cmd)
 
     def _create_from_content(self, rname, content):


### PR DESCRIPTION
Using `oc replace --force` with a DeploymentConfig may lead to broken
deployments (see https://access.redhat.com/solutions/3234391).
Specifically, this would cause issue when upgrading the service broker
during errata upgrades.

This commit applies the workaround documented in the Red Hat
Knowledgebase.

Resolves: APPU-1559