### PR TITLE
Gather networking facts before installing NetworkManager

### DIFF
--- a/playbooks/openshift-node/private/network_manager.yml
+++ b/playbooks/openshift-node/private/network_manager.yml
@@ -3,6 +3,12 @@
   hosts: oo_all_hosts
   become: yes
   tasks:
+  # the setup task is necessary to ensure that the ansible_default_ipv4 fact exists.
+  - name: Gather networking facts
+    setup:
+      gather_subset:
+        - network
+
   - name: install NetworkManager
     package:
       name: 'NetworkManager'


### PR DESCRIPTION
The fact `ansible_default_ipv4` was missing when trying to provision a
new node on a cluster that uses an EC2 dynamic inventory.

Adding an explicit setup step to gather networking facts ensures that
the fact `ansible_default_ipv4` is set.