### PR TITLE
Change Elasticsearch pod anti affinity from preferred to required

### DIFF
--- a/roles/openshift_logging_elasticsearch/templates/es.j2
+++ b/roles/openshift_logging_elasticsearch/templates/es.j2
@@ -31,15 +31,13 @@ spec:
     spec:
       affinity:
         podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
                 matchExpressions:
-                - key: logging-infra
-                  operator: In
-                  values:
-                  - elasticsearch
+                  - key: logging-infra
+                    operator: In
+                    values:
+                      - elasticsearch
               topologyKey: kubernetes.io/hostname
       terminationGracePeriod: 600
       serviceAccountName: aggregated-logging-elasticsearch


### PR DESCRIPTION
The upstream podAntiAffinity preferredDuringSchedulingIgnoredDuringExecution
does cause multiple Elasticsearch pods start on one node.
Changing it to requiredDuringSchedulingIgnoredDuringExecution
does ensure that Elasticsearch pods always start on
a dedicated node.