### PR TITLE
Implement option for iptables-min-sync-period in role openshift_node

### DIFF
--- a/roles/openshift_node/defaults/main.yml
+++ b/roles/openshift_node/defaults/main.yml
@@ -7,6 +7,7 @@ osn_storage_plugin_deps:
 - iscsi
 openshift_node_local_quota_per_fsgroup: ""
 openshift_node_proxy_mode: iptables
+openshift_node_iptables_min_sync_period: '2s'
 openshift_set_node_ip: False
 openshift_config_base: '/etc/origin'
 

--- a/roles/openshift_node/templates/node.yaml.v1.j2
+++ b/roles/openshift_node/templates/node.yaml.v1.j2
@@ -68,6 +68,10 @@ volumeDirectory: {{ openshift_node_data_dir }}/openshift.local.volumes
 proxyArguments:
   proxy-mode:
      - {{ openshift_node_proxy_mode }}
+{% if openshift_node_proxy_mode == 'iptables' %}
+  iptables-min-sync-period:
+     - {{ openshift_node_iptables_min_sync_period }}
+{% endif %}
 {% endif %}
 volumeConfig:
   localQuota:


### PR DESCRIPTION
On one of our clusters we are investigating issues with slow updates of
changing endpoints for services. RedHat support suggested that we try
increasing 'iptables-min-sync-period' to give iptables more time to
catch up when many rules need to be changed frequently.

This commit modifies the role openshift_node to allow configuring
'iptables-min-sync-period'. The default value for
iptables-min-sync-period is set to the upstream default of 2 seconds.