### PR TITLE
Cherry-pick permissions fix for namespaced service brokers

### DIFF
--- a/roles/openshift_service_catalog/files/openshift_catalog_clusterroles.yml
+++ b/roles/openshift_service_catalog/files/openshift_catalog_clusterroles.yml
@@ -10,6 +10,9 @@ rules:
   - "servicecatalog.k8s.io"
   attributeRestrictions: null
   resources:
+  - servicebrokers
+  - serviceclasses
+  - serviceplans
   - serviceinstances
   - servicebindings
   verbs:
@@ -44,6 +47,9 @@ rules:
   - "servicecatalog.k8s.io"
   attributeRestrictions: null
   resources:
+  - servicebrokers
+  - serviceclasses
+  - serviceplans
   - serviceinstances
   - servicebindings
   verbs:
@@ -78,6 +84,9 @@ rules:
   - "servicecatalog.k8s.io"
   attributeRestrictions: null
   resources:
+  - servicebrokers
+  - serviceclasses
+  - serviceplans
   - serviceinstances
   - servicebindings
   verbs:


### PR DESCRIPTION
Cherry-pick the commit introduced in https://github.com/openshift/openshift-ansible/pull/9907 to fix the missing permissions for users who create namespaced service brokers.

See also: https://bugzilla.redhat.com/show_bug.cgi?id=1623416