### PR TITLE
Add readiness + liveness probes Service Catalog API server

### DIFF
--- a/roles/openshift_service_catalog/templates/api_server.j2
+++ b/roles/openshift_service_catalog/templates/api_server.j2
@@ -63,6 +63,26 @@ spec:
         - mountPath: /etc/origin/master
           name: etcd-host-cert
           readOnly: true
+        readinessProbe:
+          httpGet:
+            port: 6443
+            path: /healthz
+            scheme: HTTPS
+          failureThreshold: 1
+          initialDelaySeconds: 30
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 5
+        livenessProbe:
+          httpGet:
+            port: 6443
+            path: /healthz
+            scheme: HTTPS
+          failureThreshold: 3
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       securityContext: {}


### PR DESCRIPTION
The kubernetes garbage collector is removing secrets,
if the OwnerReference is not available during
the service catalog api server pods are starting up.

Because the service catalog pods are started from a
daemonset, the master drain do not evict them.
This causes the kubernetes controller and the
service catalog starting at the same time.
During the startup of the controller, the
garbage collector does run at the same time
the api service is starting up.