### PR TITLE
Add openshift_node KUBELET_HOSTNAME_OVERRIDE.j2 template

### DIFF
--- a/roles/openshift_node/templates/KUBELET_HOSTNAME_OVERRIDE.j2
+++ b/roles/openshift_node/templates/KUBELET_HOSTNAME_OVERRIDE.j2
@@ -1,0 +1,1 @@
+{{ openshift_kubelet_name_override }}


### PR DESCRIPTION
The template is required for the KUBELET_HOSTNAME_OVERRIDE
override, but has been removed from the upstream
branch release-3.11.