### PR TITLE
Convert Ansible service broker secrets to json instead of yaml

### DIFF
--- a/roles/ansible_service_broker/templates/configmap.yaml.j2
+++ b/roles/ansible_service_broker/templates/configmap.yaml.j2
@@ -53,4 +53,4 @@ data:
       auth:
         - type: basic
           enabled: false
-    secrets: {{ ansible_service_broker_secrets | to_yaml }}
+    secrets: {{ ansible_service_broker_secrets | to_json }}


### PR DESCRIPTION
Converting the secrets to yaml does cause the ASB is
unable to start.

This fix as an own commit, to be able to create proper PR
for 3.10,3.11 and 4.0, as the original patch is already
merged into the branch release-4.0.