### PR TITLE
Refactor Ansible Service Broker set auth name and type facts

### DIFF
--- a/roles/ansible_service_broker/defaults/main.yml
+++ b/roles/ansible_service_broker/defaults/main.yml
@@ -20,6 +20,8 @@ ansible_service_broker_keep_namespace: false
 ansible_service_broker_image_pull_policy: Always
 ansible_service_broker_sandbox_role: edit
 ansible_service_broker_auto_escalate: false
+ansible_service_broker_registry_auth_type: "secret"
+ansible_service_broker_registry_auth_name: "asb-registry-auth"
 ansible_service_broker_local_registry_whitelist: []
 
 l_asb_default_images_dict:

--- a/roles/ansible_service_broker/tasks/install.yml
+++ b/roles/ansible_service_broker/tasks/install.yml
@@ -186,12 +186,6 @@
       path: /tmp/dcout
       data: "{{ lookup('template', 'asb_dc.yaml.j2') | from_yaml }}"
 
-- name: set auth name and type facts if needed
-  set_fact:
-    ansible_service_broker_registry_auth_type: "secret"
-    ansible_service_broker_registry_auth_name: "asb-registry-auth"
-  when: ansible_service_broker_registry_user != "" and ansible_service_broker_registry_password != ""
-
 # TODO: saw a oc_configmap in the library, but didn't understand how to get it to do the following:
 - name: Create config map for ansible-service-broker
   oc_obj:


### PR DESCRIPTION
The variables can not be overritten by
ansible_service_broker_registry_auth_type: '' and
ansible_service_broker_registry_auth_name: '' in
this case, but there are configuration
constellations an override is required.