### PR TITLE
Allow configuration of OPENSHIFT_DOCKER_BUILDER_IMAGE

### DIFF
--- a/roles/openshift_control_plane/templates/master.env.j2
+++ b/roles/openshift_control_plane/templates/master.env.j2
@@ -21,3 +21,7 @@ NO_PROXY={{ openshift.common.no_proxy | default('') }},{{ openshift.common.porta
 {% if openshift_master_debug_level is defined %}
 DEBUG_LOGLEVEL={{ openshift_master_debug_level }}
 {% endif %}
+
+{% if openshift_custom_builder_image is defined -%}
+OPENSHIFT_DOCKER_BUILDER_IMAGE='{{ openshift_custom_builder_image }}'
+{% endif -%}


### PR DESCRIPTION
Configure `OPENSHIFT_DOCKER_BUILDER_IMAGE` when the Ansible variable
openshift_custom_builder_image is defined.