### PR TITLE
Add retry to Create the Broker resource in the catalog

### DIFF
--- a/roles/ansible_service_broker/tasks/install.yml
+++ b/roles/ansible_service_broker/tasks/install.yml
@@ -408,6 +408,10 @@
   when: ansible_service_broker_registry_user != "" and ansible_service_broker_registry_password != ""
 
 - name: Create the Broker resource in the catalog
+  register: csb_create_result
+  retries: 10
+  delay: 30
+  until: csb_create_result is succeeded
   oc_obj:
     name: ansible-service-broker
     state: present


### PR DESCRIPTION
initialDelaySeconds in the deploymentconfig of the
apiserver sometimes prevent the task is
successfully executed.