### PR TITLE
Don't abort if ElasticSearch is slow

### DIFF
--- a/roles/openshift_logging_elasticsearch/tasks/restart_es_node.yml
+++ b/roles/openshift_logging_elasticsearch/tasks/restart_es_node.yml
@@ -11,7 +11,7 @@
   register: _disable_output
   changed_when:
     - "_disable_output.stdout != ''"
-    - (_disable_output.stdout | from_json)['acknowledged'] | bool
+    - (_disable_output.stdout | from_json).acknowledged | default(false) | bool
   failed_when: false
 
 - name: "Check if there is a rollout in progress for {{ _es_node }}"
@@ -70,7 +70,7 @@
   register: _enable_output
   changed_when:
     - "_enable_output.stdout != ''"
-    - (_enable_output.stdout | from_json)['acknowledged'] | bool
+    - (_enable_output.stdout | from_json).acknowledged | default(false) | bool
 
 # evaluate the RC for _dc_output
 - name: Evaluating status of rolled out pod


### PR DESCRIPTION
When disabling and reenabling shard allocation, errors are ignored. However, the `changed_when` conditions on those tasks cause the playbook to crash if Elasticsearch's response does not contain an "acknowledged" attribute. This commit addresses this.

Signed-off-by: Manuel Hutter <manuel@hutter.io>