### PR TITLE
Ensure node group labels and edits are rendered

### DIFF
--- a/roles/openshift_node_group/tasks/main.yml
+++ b/roles/openshift_node_group/tasks/main.yml
@@ -1,10 +1,14 @@
 ---
+- name: Make sure all node groups are completely rendered
+  set_fact:
+    l_openshift_node_groups: "{{ openshift_node_groups }}"
+
 - name: Build node config maps
   include_tasks: create_config.yml
   vars:
     l_openshift_node_group_name: "{{ node_group }}"
-    l_openshift_node_group_edits: "{{ (openshift_node_groups | selectattr('name', 'match', '^' ~ node_group ~ '$') | list | first).edits | default([]) }}"
-    l_openshift_node_group_labels: "{{ (openshift_node_groups | selectattr('name', 'match', '^' ~ node_group ~ '$') | list | first).labels }}"
+    l_openshift_node_group_edits: "{{ (l_openshift_node_groups | selectattr('name', 'match', '^' ~ node_group ~ '$') | list | first).edits | default([]) }}"
+    l_openshift_node_group_labels: "{{ (l_openshift_node_groups | selectattr('name', 'match', '^' ~ node_group ~ '$') | list | first).labels }}"
     # Create a unique list of openshift_node_group_names for nodes in oo_nodes_to_config
     l_active_node_group_names: "{{ hostvars
                                     | lib_utils_oo_select_keys(groups.oo_nodes_to_config)


### PR DESCRIPTION
For some node group labels we use dynamic templates that are to be
rendered at runtime.

In 57ef046, some more advanced logic was introduced to make sure, only
node groups that are actually used are created. However as a side
effect, the values used were rendered one time less. This commit makes
sure the whole "openshift_node_groups" variable is completely rendered
before usage.

Signed-off-by: Manuel Hutter <manuel@hutter.io>