### PR TITLE
Make Promehteus retention time configurable

### DIFF
--- a/roles/openshift_cluster_monitoring_operator/templates/cluster-monitoring-operator-config.j2
+++ b/roles/openshift_cluster_monitoring_operator/templates/cluster-monitoring-operator-config.j2
@@ -17,6 +17,9 @@ data:
 {% endif %}
     prometheusK8s:
       baseImage: {{ openshift_cluster_monitoring_operator_prometheus_repo }}
+{% if openshift_cluster_monitoring_operator_prometheus_retention is defined %}
+      retention: "{{ openshift_cluster_monitoring_operator_prometheus_retention }}"
+{% endif %}
 {% if openshift_cluster_monitoring_operator_node_selector is iterable and openshift_cluster_monitoring_operator_node_selector | length > 0 %}
       nodeSelector:
 {% for key, value in openshift_cluster_monitoring_operator_node_selector.items() %}


### PR DESCRIPTION
While not officially documented for OpenShift 3.11, the retention time of Prometheus can be configured within the cluster monitoring operator configuration.

This change allows that to be set with the variable `openshift_cluster_monitoring_operator_prometheus_retention`. If not set, the retention remains undefined and will default to `15d`.