### PR TITLE
WIP: Configure always a docker-registry config

### DIFF
--- a/roles/openshift_hosted/tasks/registry.yml
+++ b/roles/openshift_hosted/tasks/registry.yml
@@ -69,9 +69,7 @@
   when:
   - not (openshift_docker_hosted_registry_insecure | default(False)) | bool
 
-- include_tasks: storage/object_storage.yml
-  when:
-  - openshift_hosted_registry_storage_kind | default(none) == 'object'
+- include_tasks: storage/registry_config.yml
 
 - name: Update openshift_hosted facts for persistent volumes
   set_fact:

--- a/roles/openshift_hosted/tasks/storage/registry_config.yml
+++ b/roles/openshift_hosted/tasks/storage/registry_config.yml
@@ -32,7 +32,7 @@
     state: present
   register: svcac
 
-- name: Set facts for registry object storage
+- name: Set facts for registry config storage
   set_fact:
     registry_obj_storage_volume_mounts:
     - name: docker-config


### PR DESCRIPTION
The config file was only configured, if
object storage has been used. Because
the docker client > v19.03.0 is going
to remove the support for v2 schema v1,
we need always to add a config file
enabling the option acceptschema2
by default as it is already for
object based backend configurations.