### PR TITLE
Allow customizing initialDelaySeconds for ASB liveness probe

### DIFF
--- a/roles/ansible_service_broker/defaults/main.yml
+++ b/roles/ansible_service_broker/defaults/main.yml
@@ -39,3 +39,5 @@ ansible_service_broker_image: "{{ l_asb_image_url | regex_replace('${component}'
 #   apb_name: dh-rhscl-postgresql-apb
 # https://github.com/openshift/ansible-service-broker/blob/master/docs/config.md#secrets-configuration
 ansible_service_broker_secrets: []
+
+ansible_service_broker_liveness_initial_delay_seconds: 15

--- a/roles/ansible_service_broker/templates/asb_dc.yaml.j2
+++ b/roles/ansible_service_broker/templates/asb_dc.yaml.j2
@@ -68,7 +68,7 @@ spec:
               port: 1338
               path: /healthz
               scheme: HTTPS
-            initialDelaySeconds: 15
+            initialDelaySeconds: {{ ansible_service_broker_liveness_initial_delay_seconds }}
             timeoutSeconds: 1
       volumes:
         - name: config-volume


### PR DESCRIPTION
On clusters where many service instances are managed by the Ansible
service broker, the broker can take a couple minutes during startup to
initialize its state.

This commit allows configuring the initialDelaySeconds setting for the
ASB liveness probe in the cluster inventory, to avoid the ASB going into
a restart loop due to the liveness probe triggering a container restart
before the broker manages to initialize its state.