### PR TITLE
Implement support for configuring custom URLs for openshift-cluster-monitoring

### DIFF
--- a/roles/openshift_cluster_monitoring_operator/defaults/main.yml
+++ b/roles/openshift_cluster_monitoring_operator/defaults/main.yml
@@ -77,3 +77,7 @@ openshift_cluster_monitoring_operator_alertmanager_config: |+
   receivers:
   - name: default
   - name: deadmansswitch
+
+openshift_cluster_monitoring_prometheus_external_url: ""
+openshift_cluster_monitoring_alertmanager_external_url: ""
+openshift_cluster_monitoring_grafana_external_url: ""

--- a/roles/openshift_cluster_monitoring_operator/files/cluster-monitoring-operator.yaml
+++ b/roles/openshift_cluster_monitoring_operator/files/cluster-monitoring-operator.yaml
@@ -47,7 +47,7 @@ objects:
     resources: [daemonsets, deployments]
     verbs: [create, delete, get, list, update, watch]
   - apiGroups: [route.openshift.io]
-    resources: [routes]
+    resources: [routes, routes/custom-host]
     verbs: [create, delete, get, list, update, watch]
   - apiGroups: [security.openshift.io]
     resources: [securitycontextconstraints]

--- a/roles/openshift_cluster_monitoring_operator/templates/cluster-monitoring-operator-config.j2
+++ b/roles/openshift_cluster_monitoring_operator/templates/cluster-monitoring-operator-config.j2
@@ -38,6 +38,9 @@ data:
             requests:
               storage: {{ openshift_cluster_monitoring_operator_prometheus_storage_capacity }}
 {% endif %}
+{% if openshift_cluster_monitoring_prometheus_external_url %}
+      hostport: {{ openshift_cluster_monitoring_prometheus_external_url }}
+{% endif %}
     alertmanagerMain:
       baseImage: {{ openshift_cluster_monitoring_operator_alertmanager_repo }}
 {% if openshift_cluster_monitoring_operator_node_selector is iterable and openshift_cluster_monitoring_operator_node_selector | length > 0 %}
@@ -55,6 +58,9 @@ data:
           resources:
             requests:
               storage: {{ openshift_cluster_monitoring_operator_alertmanager_storage_capacity }}
+{% endif %}
+{% if openshift_cluster_monitoring_alertmanager_external_url %}
+      hostport: {{ openshift_cluster_monitoring_alertmanager_external_url }}
 {% endif %}
     nodeExporter:
       baseImage: {{ openshift_cluster_monitoring_operator_node_exporter_repo }}

--- a/roles/openshift_cluster_monitoring_operator/templates/cluster-monitoring-operator-config.j2
+++ b/roles/openshift_cluster_monitoring_operator/templates/cluster-monitoring-operator-config.j2
@@ -72,6 +72,9 @@ data:
         {{ key }}: "{{ value }}"
 {% endfor %}
 {% endif %}
+{% if openshift_cluster_monitoring_grafana_external_url %}
+      hostport: {{ openshift_cluster_monitoring_grafana_external_url }}
+{% endif %}
     kubeStateMetrics:
       baseImage: {{ openshift_cluster_monitoring_operator_kube_state_metrics_image }}
 {% if openshift_cluster_monitoring_operator_node_selector is iterable and openshift_cluster_monitoring_operator_node_selector | length > 0 %}


### PR DESCRIPTION
* Introduce optional variables `openshift_cluster_monitoring_prometheus_external_url`, `openshift_cluster_monitoring_alertmanager_external_url`, and `openshift_cluster_monitoring_grafana_external_url`
* Update the cluster-monitoring-operator ClusterRole to allow configuring custom hosts on routes

Note that the URL fields in the operator configmap are called `hostport` but are translated to `externalUrl` in the Prometheus and Alertmanager objects (cf. . The operator also uses the `hostport` field to configure the routes.

See https://github.com/openshift/cluster-monitoring-operator/blob/c90694f67dbc8fcb4579031a12ca10ef5ab5deb2/pkg/manifests/manifests.go for the implementation, in particular functions [`AlertmanagerRoute`](https://github.com/openshift/cluster-monitoring-operator/blob/c90694f67dbc8fcb4579031a12ca10ef5ab5deb2/pkg/manifests/manifests.go#L294-L306), [`PrometheusK8sRoute`](https://github.com/openshift/cluster-monitoring-operator/blob/c90694f67dbc8fcb4579031a12ca10ef5ab5deb2/pkg/manifests/manifests.go#L684-L696), [`GrafanaRoute`](https://github.com/openshift/cluster-monitoring-operator/blob/c90694f67dbc8fcb4579031a12ca10ef5ab5deb2/pkg/manifests/manifests.go#L1099-L1111), [`PrometheusExternalURL`](https://github.com/openshift/cluster-monitoring-operator/blob/c90694f67dbc8fcb4579031a12ca10ef5ab5deb2/pkg/manifests/manifests.go#L139-L149), and [`AlertmanagerExternalURL`](https://github.com/openshift/cluster-monitoring-operator/blob/c90694f67dbc8fcb4579031a12ca10ef5ab5deb2/pkg/manifests/manifests.go#L151-L161)