### PR TITLE
Restore rendering of kibana_env_vars in Kibana template

### DIFF
--- a/roles/openshift_logging_kibana/templates/kibana.j2
+++ b/roles/openshift_logging_kibana/templates/kibana.j2
@@ -80,6 +80,10 @@ spec:
                 resourceFieldRef:
                   containerName: kibana
                   resource: limits.memory
+{% for key, value in kibana_env_vars.items() %}
+            - name: "{{ key }}"
+              value: "{{ value }}"
+{% endfor %}
           volumeMounts:
             - name: kibana
               mountPath: /etc/kibana/keys


### PR DESCRIPTION
The role openshift_logging_kibana documents variable `openshift_logging_kibana_env_vars` which is passed to the kibana DeploymentConfig template as `kibana_env_vars`.

However this variable has never been used for ES 5.x and the variable has not had any effect since commit 6ed64e658c0bf03e20b03ad00e937c41b6465c4b.

This commit replicates the functionality which was present in the ES 2.x Kibana template to render out any provided environments variables.